### PR TITLE
Allow renaming variables via a new options.rename function

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,39 @@ var colors = scssToJson(filePath, {
 });
 ```
 
+### Renaming JSON keys
+
+Change the naming scheme of SCSS variables in the JSON output using the `rename` option:
+
+```scss
+$first-variable: red;
+$second-variable: blue;
+```
+
+```js
+var scssToJson = require('scss-to-json');
+var path = require('path');
+var camelCase = require('lodash.camelCase');
+
+var filePath = path.resolve(__dirname, 'variables.scss');
+var colors = scssToJson(filePath, {
+  rename: function(name) {
+    return camelCase(name.replace('$', ''));
+  }
+});
+```
+
+When run on the code above, scss-to-json will output the following JSON:
+
+```js
+{
+  "firstVariable": "red",
+  "secondVariable": "blue"
+}
+```
+
+The value returned by the `rename` function is used as-is, so be sure to return the original name if no changes are required. While this is best used for non-destructive renaming as shown in the above example, in the event that multiple variables are the same after renaming the JSON will include only the last-specified value.
+
 ## CLI
 
 You can also use the CLI `scss-to-json <file>`.

--- a/src/processor.js
+++ b/src/processor.js
@@ -13,12 +13,16 @@ function makeObject(declarations, options) {
   var output = {};
 
   declarations.forEach(function(declaration) {
+    var name = declaration.variable.value;
+    if (hasRename(options)) {
+      name = options.rename(name);
+    }
     if (hasScope(options)) {
       if (declaration.global) {
-        output[declaration.variable.value] = declaration.value.value;
+        output[name] = declaration.value.value;
       }
     } else {
-      output[declaration.variable.value] = declaration.value.value;
+      output[name] = declaration.value.value;
     }
   });
 
@@ -71,6 +75,10 @@ function hasScope(options) {
 
 function hasDependencies(options) {
   return options && options.dependencies && options.dependencies.length > 0;
+}
+
+function hasRename(options) {
+  return options && options.rename && typeof options.rename === 'function';
 }
 
 function normalizeLines(line) {

--- a/test/integrationTests.js
+++ b/test/integrationTests.js
@@ -101,4 +101,35 @@ describe('Integration Tests', function() {
       assert.deepEqual(compiled, output);
     });
   });
+
+  context('if rename option is specified', function() {
+    it('should compile the sample file to the correct JS object', function() {
+      var filePath = path.resolve(__dirname, 'scss', 'small-test.scss');
+      var compiled = scssToJson(filePath, {
+        rename: function(name) {
+          return name.replace('$', 'renamed-');
+        }
+      });
+      output = {
+        "renamed-first": "52px",
+        "renamed-second-variable": "red",
+      };
+
+      assert.deepEqual(compiled, output);
+    });
+
+    it('should retain the last-seen value for matching names', function() {
+      var filePath = path.resolve(__dirname, 'scss', 'small-test.scss');
+      var compiled = scssToJson(filePath, {
+        rename: function() {
+          return 'allTheSame';
+        }
+      });
+      output = {
+        "allTheSame": "red"
+      };
+
+      assert.deepEqual(compiled, output);
+    });
+  });
 });

--- a/test/scss/small-test.scss
+++ b/test/scss/small-test.scss
@@ -1,0 +1,2 @@
+$first: 52px;
+$second-variable: red;


### PR DESCRIPTION
This pull request adds a `rename` option expecting a function that, given the name of a variable in the final output, can return a modified name. As shown in the README example, I wanted to convert names to camel case for easier usability. 

If a developer chooses to rename destructively such that two distinct variables could have the same name only the last value is included in the JSON output.
