### PR TITLE
Add 4.0.0 node-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "cssmin": "^0.4.3",
     "minimist": "^1.2.0",
-    "node-sass": "^3.1.2"
+    "node-sass": "^3.1.2, ^4.0.0"
   },
   "devDependencies": {
     "cross-spawn": "2.0.0",


### PR DESCRIPTION
Without this change it causes problems when using another project that requires node-sass `^4.0.0`.