### PR TITLE
Fixes node-sass version range in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "cssmin": "^0.4.3",
     "minimist": "^1.2.0",
-    "node-sass": "^3.1.2, ^4.0.0"
+    "node-sass": ">=3.1.2 <5.0.0"
   },
   "devDependencies": {
     "cross-spawn": "2.0.0",


### PR DESCRIPTION
To avoid yarn from emitting warnings when having `scss-to-json` as a dependency of a project, change the way the version range is specified in dependencies.

```
warning Pattern ["node-sass@^3.1.2, ^4.0.0"] is trying to unpack in the same destination "/Users/vieira/Library/Caches/Yarn/v2/npm-node-sass-4.9.4-349bd7f1c89422ffe7e1e4b60f2055a69fbc5512" as pattern ["node-sass@4.9.4","node-sass@4.9.4"]. This could result in non-deterministic behavior, skipping.
```