### PR TITLE
Upgrade node-sass range to >=4.0.0 (install was failing on node 16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "cssmin": "^0.4.3",
     "minimist": "^1.2.0",
-    "node-sass": "^3.1.2, ^4.0.0"
+    "node-sass": "^3.1.2, >=4.0.0"
   },
   "devDependencies": {
     "cross-spawn": "2.0.0",


### PR DESCRIPTION
The install of the package is failing due to `node-sass` dependency - see compatibility table on between node-sass and node on their readme : https://www.npmjs.com/package/node-sass

Just allowed the range to accept major versions above 4.0.0