### PR TITLE
Upgrade node-sass dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "cssmin": "^0.4.3",
     "minimist": "^1.2.0",
-    "node-sass": "^3.1.2, ^4.0.0"
+    "node-sass": "^7.0.1"
   },
   "devDependencies": {
     "cross-spawn": "2.0.0",


### PR DESCRIPTION
Upgrade node-sass dependency version because the locked version is no longer installable.